### PR TITLE
Update integration_utils.py

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1071,6 +1071,8 @@ class MLflowCallback(TrainerCallback):
             for k, v in logs.items():
                 if isinstance(v, (int, float)):
                     metrics[k] = v
+                elif isinstance(v, torch.Tensor) and v.numel() == 1:
+                   metrics[k] = float(v)
                 else:
                     logger.warning(
                         f'Trainer is attempting to log a value of "{v}" of type {type(v)} for key "{k}" as a metric. '


### PR DESCRIPTION
Add the case where a tensor with one element is log with Mlflow

# What does this PR do?

It fixes a bug which can happend when transformers try to log a tensor with one element (generally the grad_norm) in MlFlow.


## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Approved here https://github.com/huggingface/transformers/issues/29784
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
No need
- [ ] Did you write any new necessary tests? No need, it is just two lines.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sanchit-gandhi @muellerz @pacman100

